### PR TITLE
Reduce docker image size by adding --no-install-recommends

### DIFF
--- a/3.7/linux/Dockerfile
+++ b/3.7/linux/Dockerfile
@@ -8,7 +8,7 @@ ARG PYTHON_ENV=docker-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y -q --no-install-recommends install \
     build-essential \
     ca-certificates \
     curl \

--- a/3.7/linux/Dockerfile
+++ b/3.7/linux/Dockerfile
@@ -10,6 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install required packages
 RUN apt-get update && apt-get install -y \
     build-essential \
+    ca-certificates \
     curl \
     git \
     libbz2-dev \

--- a/3.8/linux/Dockerfile
+++ b/3.8/linux/Dockerfile
@@ -8,7 +8,7 @@ ARG PYTHON_ENV=docker-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y -q --no-install-recommends install \
     build-essential \
     ca-certificates \
     curl \

--- a/3.8/linux/Dockerfile
+++ b/3.8/linux/Dockerfile
@@ -10,6 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install required packages
 RUN apt-get update && apt-get install -y \
     build-essential \
+    ca-certificates \
     curl \
     git \
     libbz2-dev \


### PR DESCRIPTION
This PR reduces the size of docker images by adding `--no-install-recommends`.

Closes #6.