### PR TITLE
Add docker image with python version 3.12 for linux

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -20,7 +20,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v3
     - name: Cache docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ matrix.version }}-${{ github.sha }}

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Setup docker buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     - name: Cache docker layers
       uses: actions/cache@v2
       with:
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-buildx-
     - name: Docker metadata
       id: docker_meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: akospasztor/docker-python
         flavor: |
@@ -39,13 +39,13 @@ jobs:
           type=raw,value=latest
           type=semver,pattern={{version}}
     - name: Login to dockerhub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PAT }}
     - name: Build docker image
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: ./${{ matrix.version }}/${{ matrix.os }}
         push: ${{ contains(github.ref, 'refs/tags/') }}

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -7,11 +7,11 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [3.7, 3.8]
+        version: [3.7, 3.8, 3.12]
         os: [linux]
         include:
           - os: linux
-            runner: ubuntu-20.04
+            runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup docker buildx
       id: buildx
       uses: docker/setup-buildx-action@v3

--- a/3.12/linux/Dockerfile
+++ b/3.12/linux/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+# Configuration
+ARG PYTHON_VERSION=3.12.1
+ARG PYTHON_ENV=docker-env
+
+# Suppress user dialogs (and selects the default answer) during apt-get install
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN apt-get update && apt-get -y -q --no-install-recommends install \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libbz2-dev \
+    libffi-dev \
+    liblzma-dev \
+    libncursesw5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    llvm \
+    make \
+    tk-dev \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install python
+ENV PYENV_ROOT=$HOME/.pyenv
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+RUN git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT
+RUN git clone https://github.com/pyenv/pyenv-virtualenv.git $PYENV_ROOT/plugins/pyenv-virtualenv
+
+RUN echo 'eval "$(pyenv init -)"' >> $HOME/.bashrc
+RUN echo 'eval "$(pyenv init -)"' >> $HOME/.bash_profile
+SHELL ["/bin/bash", "-c", "-l"]
+
+RUN pyenv install $PYTHON_VERSION
+RUN pyenv virtualenv $PYTHON_VERSION $PYTHON_ENV
+RUN pyenv global $PYTHON_ENV
+
+# Set the pyenv isntallation mode bits to allow rwX for everyone. The reason is
+# that the azure pipelines atomatically adds a new user inside the running
+# container and this user executes the job steps defined in the pipeline yml
+# file. Thus, installing packages via pip would fail (without sudo), since this
+# created user does not have permission to the pyenv root.
+# See: https://github.com/microsoft/azure-pipelines-agent/issues/2043
+RUN chmod -R a+wX $PYENV_ROOT


### PR DESCRIPTION
This pull request adds the docker image with python version 3.12.

Additionally, the GitHub Actions CI is adjusted accordingly:
- Add the new docker image with python v3.12 to the build matrix
- Update the CI runner to `ubuntu-latest`
- Update the github action versions to avoid warnings about deprecated commands caused by old github actions